### PR TITLE
Use Eloquent::getMorphClass() instead of get_class() for Morph Map support

### DIFF
--- a/src/Models/Transaction.php
+++ b/src/Models/Transaction.php
@@ -33,7 +33,7 @@ class Transaction extends Model
      {
          $currentPoint = Transaction::
          where('pointable_id', $pointable->id)
-         ->where('pointable_type', get_class($pointable))
+         ->where('pointable_type', $pointable->getMorphClass())
          ->orderBy('created_at', 'desc')
          ->lists('current')->first();
 


### PR DESCRIPTION
Added support for `Pointable` models that implement a `morphClass`.
