### PR TITLE
Fix Traits addPoints method always send null data

### DIFF
--- a/src/Traits/Pointable.php
+++ b/src/Traits/Pointable.php
@@ -93,6 +93,6 @@ trait Pointable
      */
     public function addPoints($amount, $message, $data = null)
     {
-        return (new Transaction())->addTransaction($this, $amount, $message, $data = null);
+        return (new Transaction())->addTransaction($this, $amount, $message, $data);
     }
 }


### PR DESCRIPTION
in addPoints method, always assign $data = null when call method addTransaction will replace value of data passed to method addPoints
